### PR TITLE
Improve findResourceByPath method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /lib
 /node_modules
+.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 /lib
 /node_modules
-.idea

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "files": [
     "lib"
   ],
-  "version": "0.1.5",
+  "version": "0.1.6",
   "devDependencies": {
     "babel": "^5.8.19",
     "gulp-babel": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "license": "MIT",
   "main": "lib/index.js",
-  "name": "amazon-api-gateway-client",
-  "repository": "r7kamura/amazon-api-gateway-client",
+  "name": "aws-api-gw-client",
+  "repository": "mgoria/amazon-api-gateway-client",
   "scripts": {
     "build": "gulp build",
     "test": "gulp test"
@@ -10,7 +10,7 @@
   "files": [
     "lib"
   ],
-  "version": "0.1.3",
+  "version": "0.1.4",
   "devDependencies": {
     "babel": "^5.8.19",
     "gulp-babel": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "files": [
     "lib"
   ],
-  "version": "0.1.9",
+  "version": "0.1.10",
   "devDependencies": {
     "babel": "^5.8.19",
     "gulp-babel": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "license": "MIT",
   "main": "lib/index.js",
-  "name": "aws-api-gw-client",
-  "repository": "mgoria/amazon-api-gateway-client",
+  "name": "amazon-api-gateway-client",
+  "repository": "r7kamura/amazon-api-gateway-client",
   "scripts": {
     "build": "gulp build",
     "test": "gulp test"
@@ -10,7 +10,7 @@
   "files": [
     "lib"
   ],
-  "version": "0.1.10",
+  "version": "0.1.3",
   "devDependencies": {
     "babel": "^5.8.19",
     "gulp-babel": "^5.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "files": [
     "lib"
   ],
-  "version": "0.1.4",
+  "version": "0.1.5",
   "devDependencies": {
     "babel": "^5.8.19",
     "gulp-babel": "^5.2.0",
@@ -18,7 +18,7 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "stackable-fetcher": "^0.3.0",
+    "mg-stackable-fetcher": "0.4.*",
     "stackable-fetcher-aws-signer-v4": "0.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "mocha": "^2.2.5"
   },
   "dependencies": {
-    "mg-stackable-fetcher": "0.4.*",
+    "stackable-fetcher": "^0.3.0",
     "stackable-fetcher-aws-signer-v4": "0.0.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "files": [
     "lib"
   ],
-  "version": "0.1.6",
+  "version": "0.1.9",
   "devDependencies": {
     "babel": "^5.8.19",
     "gulp-babel": "^5.2.0",

--- a/src/client.js
+++ b/src/client.js
@@ -9,7 +9,6 @@ import Model from './model'
 import path from 'path'
 import Resource from './resource'
 import Restapi from './restapi'
-import querystring from 'querystring'
 
 /**
  * @class Client
@@ -118,7 +117,10 @@ export default class Client {
    */
   findResourceByPath({ path, restapiId }) {
     return this.listResources({
-      restapiId: restapiId
+      restapiId: restapiId,
+      qsParams: {
+        limit: 500,
+      }
     }).then((resources) => {
       let matchedResource;
       resources.forEach((resource) => {
@@ -185,10 +187,9 @@ export default class Client {
    * @return {Promise}
    */
   listResources({ restapiId, qsParams = {} }) {
-    let qs = querystring.stringify(qsParams);
-
     return this.getFetcher().get(
-      `${this._getBaseUrl()}/restapis/${restapiId}/resources?${qs}`
+      `${this._getBaseUrl()}/restapis/${restapiId}/resources`,
+      qsParams
     ).then(body => body.item.map(source => new Resource(source)));
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -9,6 +9,7 @@ import Model from './model'
 import path from 'path'
 import Resource from './resource'
 import Restapi from './restapi'
+import querystring from 'querystring'
 
 /**
  * @class Client
@@ -183,9 +184,11 @@ export default class Client {
    * @param {String} restapiId
    * @return {Promise}
    */
-  listResources({ restapiId }) {
+  listResources({ restapiId, qsParams = {} }) {
+    let qs = querystring.stringify(qsParams);
+
     return this.getFetcher().get(
-      `${this._getBaseUrl()}/restapis/${restapiId}/resources`
+      `${this._getBaseUrl()}/restapis/${restapiId}/resources?${qs}`
     ).then(body => body.item.map(source => new Resource(source)));
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -9,7 +9,6 @@ import Model from './model'
 import path from 'path'
 import Resource from './resource'
 import Restapi from './restapi'
-import querystring from 'querystring'
 
 /**
  * @class Client
@@ -185,10 +184,9 @@ export default class Client {
    * @return {Promise}
    */
   listResources({ restapiId, qsParams = {} }) {
-    let qs = querystring.stringify(qsParams);
-
     return this.getFetcher().get(
-      `${this._getBaseUrl()}/restapis/${restapiId}/resources?${qs}`
+      `${this._getBaseUrl()}/restapis/${restapiId}/resources`,
+      qsParams
     ).then(body => body.item.map(source => new Resource(source)));
   }
 

--- a/src/client.js
+++ b/src/client.js
@@ -1,5 +1,5 @@
 import AwsSignerV4 from 'stackable-fetcher-aws-signer-v4'
-import { Fetcher, JsonRequestEncoder, JsonResponseDecoder, RejectLogger } from 'stackable-fetcher'
+import { Fetcher, JsonRequestEncoder, JsonResponseDecoder, RejectLogger } from 'mg-stackable-fetcher'
 import Deployment from './deployment'
 import Integration from './integration'
 import IntegrationResponse from './integration-response'


### PR DESCRIPTION
Store created api resources in client instance to avoid calls to listResources method each time a resource is looked up by path, it also fixes the bug when trying to create more than 25 resources (default limit http://docs.aws.amazon.com/apigateway/api-reference/link-relation/restapi-resources/)
