### PR TITLE
Fix error for new '_embedded' level in response

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -176,7 +176,7 @@ export default class Client {
   listDeployments({ restapiId }) {
     return this.getFetcher().get(
       `${this._getBaseUrl()}/restapis/${restapiId}/deployments`
-    ).then(body => body.item.map(source => new Deployment(source)));
+    ).then(body => body._embedded.item.map(source => new Deployment(source)));
   }
 
   /**
@@ -186,7 +186,7 @@ export default class Client {
   listResources({ restapiId }) {
     return this.getFetcher().get(
       `${this._getBaseUrl()}/restapis/${restapiId}/resources`
-    ).then(body => body.item.map(source => new Resource(source)));
+    ).then(body => body._embedded.item.map(source => new Resource(source)));
   }
 
   /**
@@ -195,7 +195,7 @@ export default class Client {
   listRestapis() {
     return this.getFetcher().get(
       `${this._getBaseUrl()}/restapis`
-    ).then(body => body.item.map(source => new Restapi(source)));
+    ).then(body => body._embedded.item.map(source => new Restapi(source)));
   }
 
   /**


### PR DESCRIPTION
When I woke up in this morning...

```
$ fluct deploy
Created zip: ./actions/yyyyy/lambda.zip
Created zip: ./actions/zzzzz/lambda.zip
Uploaded function: xxx-staging-yyyyy
Uploaded function: xxx-staging-zzzzz
TypeError: Cannot read property 'map' of undefined
    at /usr/local/lib/node_modules/fluct/node_modules/amazon-api-gateway-client/lib/client.js:304:25
    at runMicrotasksCallback (node.js:337:7)
    at process._tickDomainCallback (node.js:381:11)
```

response body:

```
{
  "_links": {
    ...
    "item": [
      ...
    ],
    ...
  },
  "_embedded": {
    "item": [
      ...
    ]
  }
}
```

it is seems to JSON Linking of HAL.
http://blog.stateless.co/post/13296666138/json-linking-with-hal

I fixed it tentatively. any other good idea?
